### PR TITLE
6-24 working repository

### DIFF
--- a/plugins/MiniAODeffi.cc
+++ b/plugins/MiniAODeffi.cc
@@ -130,7 +130,7 @@ MiniAODeffi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	int tau_position=-1;
 	for (size_t i = 0; i < GenObjects.size(); ++i) {
 		tau_position++;
-		if (GenObjects[i]->pt() > 20 && GenObjects[i]->eta()<2.3) {
+		if (GenObjects[i]->pt() > 20 && abs(GenObjects[i]->eta())<2.3) {
 			genMatchedTau_=1;
 			tauPt_=GenObjects[i]->pt();
 			tauEta_=GenObjects[i]->eta();
@@ -139,7 +139,7 @@ MiniAODeffi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 				passDiscr_=tau.tauID(tauID_);
 				dmf_=tau.tauID("decayModeFinding"); // this is the old DMF; strictly tighter than new DMF
 				double deltaR = reco::deltaR(tau, *GenObjects[i]);
-				if (tau.pt() > 20 && tau.eta()<2.3 && tau.tauID(tauID_)>.5 && abs(tau.vertex().z() - PV.z())<.2 && deltaR<maxDR_) {
+				if (tau.pt() > 20 && abs(tau.eta())<2.3 && tau.tauID(tauID_)>.5 && abs(tau.vertex().z() - PV.z())<.2 && deltaR<maxDR_) {
 					goodReco_=1;
 				} // end if tau passes criteria
 			} // end tau for loop

--- a/plugins/MiniAODeffi.cc
+++ b/plugins/MiniAODeffi.cc
@@ -31,6 +31,7 @@
 #include "helpers.h"
 
 #include "DataFormats/Math/interface/deltaR.h"
+#include "iostream"
 
 //
 // class declaration
@@ -115,6 +116,11 @@ MiniAODeffi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}	
 	
 	for (size_t i = 0; i < GenTaus.size(); i++) { //Loop through all generated taus
+		for(size_t j = 0; j < GenTaus[i]->numberOfDaughters(); ++j){ //Loop through daughters of gen. tau
+			if (abs(GenTaus[i]->daughter(j)->pdgId()) == 11 || abs(GenTaus[i]->daughter(j)->pdgId()) == 13){ //Check if the daughter is another lepton
+				goto nothadronictau;                           //Skip over non-hadronic tau decays
+			}
+		}
 		if (GenTaus[i]->pt() > 20 && abs(GenTaus[i]->eta())<2.3) {
 			tauPt_= GenTaus[i]->pt();
 			tauEta_= GenTaus[i]->eta();
@@ -130,6 +136,7 @@ MiniAODeffi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 				tauIndex_++;
 			} // end tau for loop
 			tree->Fill();
+			nothadronictau:;
 		} //end if gen tau matches critera
 	} //end gen tau for loop   
 }

--- a/plugins/MiniAODfakeRate.cc
+++ b/plugins/MiniAODfakeRate.cc
@@ -183,7 +183,7 @@ MiniAODfakeRate_alt::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
                 jetIDTight_=0;
                 iJet++;
 		//	pass_vert = (jet.vertex().z() - PV.z()) < .2 && tau.dxy() < .045
-		if (jet.pt() > 20&&jet.eta()<2.3&&(isLooseJet(jet))) {
+		if (jet.pt() > 20&&abs(jet.eta())<2.3&&(isLooseJet(jet))) {
                 //std::cout << "The Jet PT is >20, jetEta<2.3, it is loose \n";
         	        jetPt_=jet.pt();
                 	jetEta_=jet.eta();
@@ -225,7 +225,7 @@ MiniAODfakeRate_alt::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 		//std::cout << "Analyzing Tau number " << tau_position << "\n";
 		bool pass_discr = tau.tauID(tauID_)>.5 && tau.tauID("againstElectronVLooseMVA5")>.5 && tau.tauID("againstMuonTight3");
 		bool pass_vert = (tau.vertex().z() - PV.z()) < .2; // && tau.dxy() < .045
-                if (tau.pt() > 20&&tau.eta()<2.3&& pass_discr && pass_vert) { // if the tau passes the critera
+                if (tau.pt() > 20&&abs(tau.eta())<2.3&& pass_discr && pass_vert) { // if the tau passes the critera
 			passDiscr_=1;
 			const reco::GenParticle* bestGenTau = findBestGenMatch(tau,GenTaus,maxDR_);
 			const reco::GenParticle* bestGenEle = findBestGenMatch(tau,GenEles,maxDR_);

--- a/test/plot_Mini_FR_ZToEE.py
+++ b/test/plot_Mini_FR_ZToEE.py
@@ -17,7 +17,9 @@ import ROOT
 ROOT.gROOT.SetStyle("Plain")
 ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
-
+ROOT.gStyle.SetPadTopMargin(0.15)
+ROOT.gStyle.SetTitleX(0.1)
+ROOT.gStyle.SetTitleY(0.95)
 ######## File #########
 if len(argv) < 2:
    print 'Usage:python plot.py RootFile.root label[optional]'
@@ -47,11 +49,12 @@ ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Ntuple")
 puCorrPtSum = ntuple_file.Get("puCorrPtSum/Ntuple")
 MuLoose3 = ntuple_file.Get("againstMuonLoose3/Ntuple")
 MuTight3 = ntuple_file.Get("againstMuonTight3/Ntuple")
-EleVLooseMVA5 = ntuple_file.Get("againstElectronVLooseMVA5/Ntuple")
-EleLooseMVA5 = ntuple_file.Get("againstElectronLooseMVA5/Ntuple")
-EleMediumMVA5 = ntuple_file.Get("againstElectronMediumMVA5/Ntuple")
-
-canvas = ROOT.TCanvas("asdf", "adsf", 800, 800)
+EleVLooseMVA6 = ntuple_file.Get("againstElectronVLooseMVA6/Ntuple")
+EleLooseMVA6 = ntuple_file.Get("againstElectronLooseMVA6/Ntuple")
+EleMediumMVA6 = ntuple_file.Get("againstElectronMediumMVA6/Ntuple")
+EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Ntuple")
+EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Ntuple")
+canvas = ROOT.TCanvas("asdf", "adsf", 1200, 800)
 
 def make_plot(tree, variable, selection, binning, xaxis='', title=''):
     ''' Plot a variable using draw and return the histogram '''
@@ -73,7 +76,7 @@ def make_efficiency(denom, num):
 def make_num(ntuple, variable,PtCut,binning):
     num = make_plot(
         ntuple, variable,
-	"passTau",
+	"fakeEle",
         binning
     )
     return num
@@ -81,7 +84,7 @@ def make_num(ntuple, variable,PtCut,binning):
 def make_denom(ntuple, variable,PtCut,binning):
     denom = make_plot(
         ntuple, variable,
-        "passEle",
+        "",
         binning
     )
     return denom
@@ -93,21 +96,28 @@ def produce_efficiency(ntuple, variable, PtCut,binning, filename,color):
     l1.SetMarkerColor(color)
     return l1
 
-def compare_efficiencies(ntuple1,legend1,ntuple2, legend2, variable, PtCut, binning, filename,
+def compare_efficiencies(ntuple1,legend1,ntuple2, legend2, variable, PtCut, binning, filename,framemin,framemax,
                          title='', xaxis='',yaxis=''):
     frame = ROOT.TH1F("frame", "frame", *binning)
     l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
     l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
-    frame.SetMaximum(.2)
-    frame.SetMinimum(.0001)
+    frame.SetMaximum(framemax)
+    frame.SetMinimum(framemin)
     frame.SetTitle(title)
+    frame.UseCurrentStyle()
     frame.GetXaxis().SetTitle(xaxis)
     frame.GetYaxis().SetTitle(yaxis)
+    frame.GetYaxis().SetTitleOffset(1.2)
+    frame.GetYaxis().CenterTitle()
+    frame.UseCurrentStyle()
     frame.Draw()
     l1.Draw('pe')
     l2.Draw('pesame')
     canvas.SetLogy()
-    legend = ROOT.TLegend(0.5, 0.7, 0.95, 0.9, "", "brNDC")
+    legend = ROOT.TLegend(0.6, 0.7, 1.0, 0.9, "", "brNDC")
+    legend.SetFillColor(ROOT.kWhite)
+    canvas.SetLogy()
+    legend = ROOT.TLegend(0.65, 0.85, 0.9, 1.0, "", "brNDC")
     legend.SetFillColor(ROOT.kWhite)
     legend.SetBorderSize(1)
     legend.AddEntry(l1,legend1, "pe")
@@ -117,23 +127,27 @@ def compare_efficiencies(ntuple1,legend1,ntuple2, legend2, variable, PtCut, binn
     print saveas
     canvas.SaveAs(saveas)
 
-def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, variable, PtCut, binning, filename,
+def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, variable, PtCut, binning, filename,framemin,framemax,
                          title='', xaxis='',yaxis=''):
     frame = ROOT.TH1F("frame", "frame", *binning)
     l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
     l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
     l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kRed+3)
-    frame.SetMaximum(.1)
-    frame.SetMinimum(.0001)
+    frame.SetMinimum(framemin)
+    frame.SetMaximum(framemax)
     frame.SetTitle(title)
+    frame.UseCurrentStyle()
     frame.GetXaxis().SetTitle(xaxis)
     frame.GetYaxis().SetTitle(yaxis)
+    frame.GetYaxis().SetTitleOffset(1.2)
+    frame.GetYaxis().CenterTitle()
+    frame.GetXaxis().CenterTitle()
     frame.Draw()
     l1.Draw('pe')
     l2.Draw('pesame')
     l3.Draw('pesame')
     canvas.SetLogy()
-    legend = ROOT.TLegend(0.5, 0.7, 0.95, 0.9, "", "brNDC")
+    legend = ROOT.TLegend(0.65, 0.85, 0.9, 1.0, "", "brNDC")
     legend.SetFillColor(ROOT.kWhite)
     legend.SetBorderSize(1)
     legend.AddEntry(l1,legend1, "pe")
@@ -144,92 +158,123 @@ def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, var
     print saveas
     canvas.SaveAs(saveas)
 
+def compare_5efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3,ntuple4,legend4,ntuple5,legend5, variable, PtCut, binning, filename,framemin,framemax,
+                         title='', xaxis='',yaxis=''):
+    frame = ROOT.TH1F("frame", "frame", *binning)
+    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kRed-3)
+    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kRed+3)
+    l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kBlue+3)
+    l4 = produce_efficiency(ntuple4,variable, PtCut,binning, filename,ROOT.kGreen-3)
+    l5 = produce_efficiency(ntuple5,variable, PtCut,binning, filename,ROOT.kGreen+3)
+    frame.SetMinimum(framemin)
+    frame.SetMaximum(framemax)
+    frame.SetTitle(title)
+    frame.UseCurrentStyle()
+    frame.GetXaxis().SetTitle(xaxis)
+    frame.GetYaxis().SetTitle(yaxis)
+    frame.GetYaxis().SetTitleOffset(1.2)
+    frame.GetYaxis().CenterTitle()
+    frame.GetXaxis().CenterTitle()
+    frame.Draw()
+    l1.Draw('pe')
+    l2.Draw('pesame')
+    l3.Draw('pesame')
+    l4.Draw('pesame')
+    l5.Draw('pesame')
+    canvas.SetLogy()
+    legend = ROOT.TLegend(0.65, 0.85, 0.9, 1.0, "", "brNDC")
+    legend.SetFillColor(ROOT.kWhite)
+    legend.SetBorderSize(1)
+    legend.AddEntry(l1,legend1, "pe")
+    legend.AddEntry(l2,legend2, "pe")
+    legend.AddEntry(l3,legend3, "pe")
+    legend.AddEntry(l4,legend4, "pe")
+    legend.AddEntry(l5,legend5, "pe")
+    legend.Draw()
+    saveas = saveWhere+filename+'.png'
+    print saveas
+    canvas.SaveAs(saveas)
+
 ################################################################################
 # Efficiency for a 20 GeV cut on tau Pt 
 ################################################################################
 ## pT plots
 compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','elePt', 20, [20, 0, 120],#variable, ptcut, binning
-                    'tau_iso_fakeRate_pT_Electrons',#filename
-                    "Tau Fake Rate (Electrons)",#title
+                    'tau_iso_fakeRate_pT_Electrons', 3e-1, 1,#filename
+                    "Tau Fake Efficiency (Electrons)",#title
                     "Electron p_{T} (GeV)",#xaxis
-                    "fake rate" #yaxis             
+                    "Fake Efficiency" #yaxis
+             
 )
 
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','elePt',20,[20,0,120],
-                    'tau_PtSum_fakeRate_pT_Electrons',
-                    "Tau Fake Rate (Electrons)",
+                    'tau_PtSum_fakeRate_pT_Electrons', 1e-1, 1,
+                    "Tau Fake Efficiency (Electrons)",
                     "Electron p_{T} (GeV)",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
 compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','elePt',20,[20,0,120],
-                    'tau_Mu_fakeRate_pT_Electrons',
-                    "Tau Fake Rate (Electrons)",
+                    'tau_Mu_fakeRate_pT_Electrons', 6e-1, 1,
+                    "Tau Fake Efficiency (Electrons)",
                     "Electron p_{T} (GeV)",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
-compare_3efficiencies(EleVLooseMVA5,'againstElectronVLooseMVA5',EleLooseMVA5,'againstElectronLooseMVA5',EleMediumMVA5,'againstElectronMediumMVA5','elePt',20,[20,0,120],
-                    'tau_Ele_fakeRate_pT_Electrons',
-                    "Tau Fake Rate (Electrons)",
+compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','elePt',20,[20,0,120],
+                    'tau_Ele_fakeRate_pT_Electrons', 1e-4, 1e-1,
+                    "Tau Fake Efficiency (Electrons)",
                     "Electron p_{T} (GeV)",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
 ## eta plots
 compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','eleEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
-                    'tau_iso_fakeRate_eta_Electrons',#filename
-                    "Tau Fake Rate (Electrons)",#title
+                    'tau_iso_fakeRate_eta_Electrons', 3e-1, 1,#filename
+                    "Tau Fake Efficiency (Electrons)",#title
                     "Electron Eta",#xaxis
-                    "fake rate" #yaxis             
+                    "Fake Efficiency" #yaxis             
 )
 
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','eleEta',20,[20,-2.4,2.4],
-                    'tau_PtSum_fakeRate_eta_Electrons',
-                    "Tau Fake Rate (Electrons)",
+                    'tau_Mu_fakeRate_eta_Electrons',1e-1,1,
+                    "Tau Fake Efficiency (Electrons)",
                     "Electron Eta",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','eleEta',20,[20,-2.4,2.4],
-                    'tau_Mu_fakeRate_eta_Electrons',
-                    "Tau Fake Rate (Electrons)",
+compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','eleEta',20,[20,-2.4,2.4],
+                    'tau_Ele_fakeRate_eta_Electrons',1e-4, 1e-1,
+                    "Tau Fake Efficiency (Electrons)",
                     "Electron Eta",
-                    "fake rate"
-)
-
-compare_3efficiencies(EleVLooseMVA5,'againstElectronVLooseMVA5',EleLooseMVA5,'againstElectronLooseMVA5',EleMediumMVA5,'againstElectronMediumMVA5','eleEta',20,[20,-2.4,2.4],
-                    'tau_Ele_fakeRate_eta_Electrons',
-                    "Tau Fake Rate (Electrons)",
-                    "Electron Eta",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
 ## nvtx plots
 compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','nvtx', 20, [20,0,35],#variable, ptcut, binning
-                    'tau_iso_fakeRate_nvtx_Electrons',#filename
-                    "Tau Fake Rate (Electrons)",#title
+                    'tau_iso_fakeRate_nvtx_Electrons',3e-1,1,#filename
+                    "Tau Fake Efficiency (Electrons)",#title
                     "N_{vtx}",#xaxis
-                    "fake rate" #yaxis             
+                    "Fake Efficiency" #yaxis             
 )
 
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','nvtx',20,[20,0,35],
-                    'tau_PtSum_fakeRate_nvtx_Electrons',
-                    "Tau Fake Rate (Electrons)",
+                    'tau_PtSum_fakeRate_nvtx_Electrons',1e-1,1,
+                    "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
 compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','nvtx',20,[20,0,35],
-                    'tau_Mu_fakeRate_nvtx_Electrons',
-                    "Tau Fake Rate (Electrons)",
+                    'tau_Mu_fakeRate_nvtx_Electrons',6e-1, 1,
+                    "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
-                    "fake rate"
+                    "Fake Efficiency"
 )
 
-compare_3efficiencies(EleVLooseMVA5,'againstElectronVLooseMVA5',EleLooseMVA5,'againstElectronLooseMVA5',EleMediumMVA5,'againstElectronMediumMVA5','nvtx',20,[20,0,35],
-                    'tau_Ele_fakeRate_nvtx_Electrons',
-                    "Tau Fake Rate (Electrons)",
+compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','nvtx',20,[20,0,35],
+                    'tau_Ele_fakeRate_nvtx_Electrons',1e-4,1e-1,
+                    "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
-                    "fake rate"
+                    "Fake Efficiency"
 )

--- a/test/plot_Mini_FR_ZToEE.py
+++ b/test/plot_Mini_FR_ZToEE.py
@@ -1,7 +1,7 @@
 '''
 Usage:python plot.py RootFile.root label[optional]
 
-Script to make some quick efficiency plots to test ntuple generation.
+Script to make some quick fake rate plots to test ntuple generation.
 
 
 Author: L. Dodd, UW Madison
@@ -18,8 +18,11 @@ ROOT.gROOT.SetStyle("Plain")
 ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPadTopMargin(0.15)
+ROOT.gStyle.SetPadGridY(1) 
 ROOT.gStyle.SetTitleX(0.1)
 ROOT.gStyle.SetTitleY(0.95)
+colors=[ROOT.kCyan,ROOT.kGreen,ROOT.kOrange,ROOT.kRed,ROOT.kBlue]  #Add more colors for >5 sets of points in a single plot
+
 ######## File #########
 if len(argv) < 2:
    print 'Usage:python plot.py RootFile.root label[optional]'
@@ -29,31 +32,27 @@ infile = argv[1]
 ntuple_file = ROOT.TFile(infile)
 
 ######## LABEL & SAVE WHERE #########
-
 if len(argv)>2:
-   saveWhere='~/private/output/tauAnalysis/'+argv[2]+'_'
+   saveWhere='~/private/output/tauAnalysis/7_6_5/'+argv[2]+'_'
 else:
-   saveWhere='~/private/output/tauAnalysis/'
-
-
+   saveWhere='~/private/output/tauAnalysis/7_6_5/'
 
 #####################################
-#Get Effi NTUPLE                 #
+#Get fakerate NTUPLE                 #
 #####################################
-
-byLooseCmbIso3 = ntuple_file.Get("byLooseCombinedIsolationDeltaBetaCorr3Hits/Ntuple")
-byMedCmbIso3 = ntuple_file.Get("byMediumCombinedIsolationDeltaBetaCorr3Hits/Ntuple")
-byTightCmbIso3 = ntuple_file.Get("byTightCombinedIsolationDeltaBetaCorr3Hits/Ntuple")
-
-ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Ntuple")
-puCorrPtSum = ntuple_file.Get("puCorrPtSum/Ntuple")
-MuLoose3 = ntuple_file.Get("againstMuonLoose3/Ntuple")
-MuTight3 = ntuple_file.Get("againstMuonTight3/Ntuple")
-EleVLooseMVA6 = ntuple_file.Get("againstElectronVLooseMVA6/Ntuple")
-EleLooseMVA6 = ntuple_file.Get("againstElectronLooseMVA6/Ntuple")
-EleMediumMVA6 = ntuple_file.Get("againstElectronMediumMVA6/Ntuple")
-EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Ntuple")
-EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Ntuple")
+byLooseCmbIso3 = ntuple_file.Get("byLooseCombinedIsolationDeltaBetaCorr3Hits/Gen. Ele")
+byMedCmbIso3 = ntuple_file.Get("byMediumCombinedIsolationDeltaBetaCorr3Hits/Gen. Ele")
+byTightCmbIso3 = ntuple_file.Get("byTightCombinedIsolationDeltaBetaCorr3Hits/Gen. Ele")
+ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Gen. Ele")
+puCorrPtSum = ntuple_file.Get("puCorrPtSum/Gen. Ele")
+MuLoose3 = ntuple_file.Get("againstMuonLoose3/Gen. Ele")
+MuTight3 = ntuple_file.Get("againstMuonTight3/Gen. Ele")
+EleVLooseMVA6 = ntuple_file.Get("againstElectronVLooseMVA6/Gen. Ele")
+EleLooseMVA6 = ntuple_file.Get("againstElectronLooseMVA6/Gen. Ele")
+EleMediumMVA6 = ntuple_file.Get("againstElectronMediumMVA6/Gen. Ele")
+EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Gen. Ele")
+EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Gen. Ele")
+print EleVTightMVA6
 canvas = ROOT.TCanvas("asdf", "adsf", 1200, 800)
 
 def make_plot(tree, variable, selection, binning, xaxis='', title=''):
@@ -65,8 +64,8 @@ def make_plot(tree, variable, selection, binning, xaxis='', title=''):
     output_histo.SetTitle(title)
     return output_histo
 
-def make_efficiency(denom, num):
-    ''' Make an efficiency graph with the style '''
+def make_fakerate(denom, num):
+    ''' Make a fake rate graph with the style '''
     eff = ROOT.TGraphAsymmErrors(num, denom)
     eff.SetMarkerStyle(20)
     eff.SetMarkerSize(1.5)
@@ -89,196 +88,129 @@ def make_denom(ntuple, variable,PtCut,binning):
     )
     return denom
 
-def produce_efficiency(ntuple, variable, PtCut,binning, filename,color):
+def produce_fakerate(ntuple, variable, PtCut,binning, filename,color):
     denom = make_denom(ntuple, variable,PtCut,binning)
     num = make_num(ntuple,variable,PtCut,binning)
-    l1 = make_efficiency(denom,num)
+    l1 = make_fakerate(denom,num)
     l1.SetMarkerColor(color)
     return l1
 
-def compare_efficiencies(ntuple1,legend1,ntuple2, legend2, variable, PtCut, binning, filename,framemin,framemax,
-                         title='', xaxis='',yaxis=''):
-    frame = ROOT.TH1F("frame", "frame", *binning)
-    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
-    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
-    frame.SetMaximum(framemax)
-    frame.SetMinimum(framemin)
-    frame.SetTitle(title)
-    frame.UseCurrentStyle()
-    frame.GetXaxis().SetTitle(xaxis)
-    frame.GetYaxis().SetTitle(yaxis)
-    frame.GetYaxis().SetTitleOffset(1.2)
-    frame.GetYaxis().CenterTitle()
-    frame.UseCurrentStyle()
-    frame.Draw()
-    l1.Draw('pe')
-    l2.Draw('pesame')
-    canvas.SetLogy()
-    legend = ROOT.TLegend(0.6, 0.7, 1.0, 0.9, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    canvas.SetLogy()
-    legend = ROOT.TLegend(0.65, 0.85, 0.9, 1.0, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    legend.SetBorderSize(1)
-    legend.AddEntry(l1,legend1, "pe")
-    legend.AddEntry(l2,legend2, "pe")
-    legend.Draw()
-    saveas = saveWhere+filename+'.png'
-    print saveas
-    canvas.SaveAs(saveas)
-
-def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, variable, PtCut, binning, filename,framemin,framemax,
-                         title='', xaxis='',yaxis=''):
-    frame = ROOT.TH1F("frame", "frame", *binning)
-    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
-    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
-    l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kRed+3)
-    frame.SetMinimum(framemin)
-    frame.SetMaximum(framemax)
-    frame.SetTitle(title)
-    frame.UseCurrentStyle()
-    frame.GetXaxis().SetTitle(xaxis)
-    frame.GetYaxis().SetTitle(yaxis)
-    frame.GetYaxis().SetTitleOffset(1.2)
-    frame.GetYaxis().CenterTitle()
-    frame.GetXaxis().CenterTitle()
-    frame.Draw()
-    l1.Draw('pe')
-    l2.Draw('pesame')
-    l3.Draw('pesame')
-    canvas.SetLogy()
-    legend = ROOT.TLegend(0.65, 0.85, 0.9, 1.0, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    legend.SetBorderSize(1)
-    legend.AddEntry(l1,legend1, "pe")
-    legend.AddEntry(l2,legend2, "pe")
-    legend.AddEntry(l3,legend3, "pe")
-    legend.Draw()
-    saveas = saveWhere+filename+'.png'
-    print saveas
-    canvas.SaveAs(saveas)
-
-def compare_5efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3,ntuple4,legend4,ntuple5,legend5, variable, PtCut, binning, filename,framemin,framemax,
-                         title='', xaxis='',yaxis=''):
-    frame = ROOT.TH1F("frame", "frame", *binning)
-    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kRed-3)
-    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kRed+3)
-    l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kBlue+3)
-    l4 = produce_efficiency(ntuple4,variable, PtCut,binning, filename,ROOT.kGreen-3)
-    l5 = produce_efficiency(ntuple5,variable, PtCut,binning, filename,ROOT.kGreen+3)
-    frame.SetMinimum(framemin)
-    frame.SetMaximum(framemax)
-    frame.SetTitle(title)
-    frame.UseCurrentStyle()
-    frame.GetXaxis().SetTitle(xaxis)
-    frame.GetYaxis().SetTitle(yaxis)
-    frame.GetYaxis().SetTitleOffset(1.2)
-    frame.GetYaxis().CenterTitle()
-    frame.GetXaxis().CenterTitle()
-    frame.Draw()
-    l1.Draw('pe')
-    l2.Draw('pesame')
-    l3.Draw('pesame')
-    l4.Draw('pesame')
-    l5.Draw('pesame')
-    canvas.SetLogy()
-    legend = ROOT.TLegend(0.65, 0.85, 0.9, 1.0, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    legend.SetBorderSize(1)
-    legend.AddEntry(l1,legend1, "pe")
-    legend.AddEntry(l2,legend2, "pe")
-    legend.AddEntry(l3,legend3, "pe")
-    legend.AddEntry(l4,legend4, "pe")
-    legend.AddEntry(l5,legend5, "pe")
-    legend.Draw()
-    saveas = saveWhere+filename+'.png'
-    print saveas
-    canvas.SaveAs(saveas)
+#Accepts any number of ntuples and plots them for comparison; works well up to at least 5
+def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename, framemin, framemax, title='', xaxis='',yaxis=''):
+	frame = ROOT.TH1F("frame", "frame", *binning)
+	histlist = []
+	for i in range(len(ntuples)):
+		histlist.append(produce_fakerate(ntuples[i],variable, PtCut,binning, filename,colors[i]))
+    	frame.SetMaximum(framemax)
+    	frame.SetMinimum(framemin)
+    	frame.SetTitle(title)
+    	frame.UseCurrentStyle()
+    	frame.GetXaxis().SetTitle(xaxis)
+    	frame.GetYaxis().SetTitle(yaxis)
+    	frame.GetYaxis().SetTitleOffset(1.2)
+    	frame.GetYaxis().CenterTitle()
+    	frame.GetXaxis().CenterTitle()
+    	frame.UseCurrentStyle()
+    	frame.Draw()
+	canvas.SetLogy()
+	for i in range(len(histlist)):
+		if i == 0:
+			histlist[i].Draw('pe')
+		else:
+			histlist[i].Draw('pesame')
+    	legend = ROOT.TLegend(0.65,0.85 ,0.9,1.0, "", "brNDC")
+    	legend.SetFillColor(ROOT.kWhite)
+    	legend.SetBorderSize(1)
+	for i in range(len(legends)):
+		legend.AddEntry(histlist[i],legends[i],'pe')
+    	legend.Draw()
+    	saveas = saveWhere+filename+'.png'
+    	print saveas
+    	canvas.SaveAs(saveas)
 
 ################################################################################
-# Efficiency for a 20 GeV cut on tau Pt 
+# Fake Efficiency for a 20 GeV cut on tau Pt 
 ################################################################################
 ## pT plots
-compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','elePt', 20, [20, 0, 120],#variable, ptcut, binning
-                    'tau_iso_fakeRate_pT_Electrons', 3e-1, 1,#filename
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'elePt', 20, [20, 0, 120],#variable, ptcut, binning
+                    'tau_iso_fakerate_pT',3e-1,1, #filename, lower bound (y), upper bound (y)
                     "Tau Fake Efficiency (Electrons)",#title
-                    "Electron p_{T} (GeV)",#xaxis
-                    "Fake Efficiency" #yaxis
-             
+                    "Tau p_{T} (GeV)",#xaxis
+                    "Fake Efficiency" #yaxis            
 )
 
-compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','elePt',20,[20,0,120],
-                    'tau_PtSum_fakeRate_pT_Electrons', 1e-1, 1,
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'elePt',20,[20,0,120],
+                    'tau_PtSum_fakerate_pT',1e-1,1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Electron p_{T} (GeV)",
+                    "Tau p_{T} (GeV)",
                     "Fake Efficiency"
 )
 
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','elePt',20,[20,0,120],
-                    'tau_Mu_fakeRate_pT_Electrons', 6e-1, 1,
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'elePt',20,[20,0,120],
+                    'tau_Mu_fakerate_pT',6e-1,1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Electron p_{T} (GeV)",
+                    "Tau p_{T} (GeV)",
                     "Fake Efficiency"
 )
 
-compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','elePt',20,[20,0,120],
-                    'tau_Ele_fakeRate_pT_Electrons', 1e-4, 1e-1,
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'elePt',20,[20,0,120],
+                    'tau_Ele_fakerate_pT',1e-4,1e-1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Electron p_{T} (GeV)",
+                    "Tau p_{T} (GeV)",
                     "Fake Efficiency"
 )
 
 ## eta plots
-compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','eleEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
-                    'tau_iso_fakeRate_eta_Electrons', 3e-1, 1,#filename
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'eleEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
+                    'tau_iso_fakerate_eta', 3e-1, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Fake Efficiency (Electrons)",#title
-                    "Electron Eta",#xaxis
+                    "Tau #eta",#xaxis
                     "Fake Efficiency" #yaxis             
 )
-compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','eleEta',20,[20,-2.4,2.4],
-                    'tau_PtSum_fakeRate_eta_Electrons',1e-1,1,
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'eleEta',20,[20,-2.4,2.4],
+                    'tau_PtSum_fakerate_eta',1e-1, 1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Electron Eta",
+                    "Tau #eta",
                     "Fake Efficiency"
 )
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','eleEta',20,[20,-2.4,2.4],
-                    'tau_Mu_fakeRate_eta_Electrons',6e-1,1,
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'eleEta',20,[20,-2.4,2.4],
+                    'tau_Mu_fakerate_eta',6e-1, 1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Electron Eta",
+                    "Tau #eta",
                     "Fake Efficiency"
 )
 
-compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','eleEta',20,[20,-2.4,2.4],
-                    'tau_Ele_fakeRate_eta_Electrons',1e-4, 1e-1,
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'eleEta',20,[20,-2.4,2.4],
+                    'tau_Ele_fakerate_eta',1e-4, 1e-1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Electron Eta",
+                    "Tau #eta",
                     "Fake Efficiency"
 )
 
 ## nvtx plots
-compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','nvtx', 20, [20,0,35],#variable, ptcut, binning
-                    'tau_iso_fakeRate_nvtx_Electrons',3e-1,1,#filename
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'nvtx', 20, [20,0,35],#variable, ptcut, binning
+                    'tau_iso_fakerate_nvtx',3e-1, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Fake Efficiency (Electrons)",#title
                     "N_{vtx}",#xaxis
                     "Fake Efficiency" #yaxis             
 )
 
-compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','nvtx',20,[20,0,35],
-                    'tau_PtSum_fakeRate_nvtx_Electrons',1e-1,1,
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'nvtx',20,[20,0,35],
+                    'tau_PtSum_fakerate_nvtx',1e-1, 1,
                     "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
                     "Fake Efficiency"
 )
 
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','nvtx',20,[20,0,35],
-                    'tau_Mu_fakeRate_nvtx_Electrons',6e-1, 1,
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'nvtx',20,[20,0,35],
+                    'tau_Mu_fakerate_nvtx',6e-1, 1,
                     "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
                     "Fake Efficiency"
 )
 
-compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','nvtx',20,[20,0,35],
-                    'tau_Ele_fakeRate_nvtx_Electrons',1e-4,1e-1,
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'nvtx',20,[20,0,35],
+                    'tau_Ele_fakerate_nvtx',1e-4, 1e-1,
                     "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
                     "Fake Efficiency"

--- a/test/plot_Mini_FR_ZToEE.py
+++ b/test/plot_Mini_FR_ZToEE.py
@@ -17,10 +17,10 @@ import ROOT
 ROOT.gROOT.SetStyle("Plain")
 ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
-ROOT.gStyle.SetPadTopMargin(0.15)
-ROOT.gStyle.SetPadGridY(1) 
-ROOT.gStyle.SetTitleX(0.1)
-ROOT.gStyle.SetTitleY(0.95)
+#ROOT.gStyle.SetPadTopMargin(0.15)
+#ROOT.gStyle.SetPadGridY(1) 
+#ROOT.gStyle.SetTitleX(0.1)
+#ROOT.gStyle.SetTitleY(0.95)
 colors=[ROOT.kCyan,ROOT.kGreen,ROOT.kOrange,ROOT.kRed,ROOT.kBlue]  #Add more colors for >5 sets of points in a single plot
 
 ######## File #########
@@ -40,18 +40,18 @@ else:
 #####################################
 #Get fakerate NTUPLE                 #
 #####################################
-byLooseCmbIso3 = ntuple_file.Get("byLooseCombinedIsolationDeltaBetaCorr3Hits/Gen. Ele")
-byMedCmbIso3 = ntuple_file.Get("byMediumCombinedIsolationDeltaBetaCorr3Hits/Gen. Ele")
-byTightCmbIso3 = ntuple_file.Get("byTightCombinedIsolationDeltaBetaCorr3Hits/Gen. Ele")
-ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Gen. Ele")
-puCorrPtSum = ntuple_file.Get("puCorrPtSum/Gen. Ele")
-MuLoose3 = ntuple_file.Get("againstMuonLoose3/Gen. Ele")
-MuTight3 = ntuple_file.Get("againstMuonTight3/Gen. Ele")
-EleVLooseMVA6 = ntuple_file.Get("againstElectronVLooseMVA6/Gen. Ele")
-EleLooseMVA6 = ntuple_file.Get("againstElectronLooseMVA6/Gen. Ele")
-EleMediumMVA6 = ntuple_file.Get("againstElectronMediumMVA6/Gen. Ele")
-EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Gen. Ele")
-EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Gen. Ele")
+byLooseCmbIso3 = ntuple_file.Get("byLooseCombinedIsolationDeltaBetaCorr3Hits/Gen. Mu")
+byMedCmbIso3 = ntuple_file.Get("byMediumCombinedIsolationDeltaBetaCorr3Hits/Gen. Mu")
+byTightCmbIso3 = ntuple_file.Get("byTightCombinedIsolationDeltaBetaCorr3Hits/Gen. Mu")
+ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Gen. Mu")
+puCorrPtSum = ntuple_file.Get("puCorrPtSum/Gen. Mu")
+MuLoose3 = ntuple_file.Get("againstMuonLoose3/Gen. Mu")
+MuTight3 = ntuple_file.Get("againstMuonTight3/Gen. Mu")
+EleVLooseMVA6 = ntuple_file.Get("againstElectronVLooseMVA6/Gen. Mu")
+EleLooseMVA6 = ntuple_file.Get("againstElectronLooseMVA6/Gen. Mu")
+EleMediumMVA6 = ntuple_file.Get("againstElectronMediumMVA6/Gen. Mu")
+EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Gen. Mu")
+EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Gen. Mu")
 print EleVTightMVA6
 canvas = ROOT.TCanvas("asdf", "adsf", 1200, 800)
 
@@ -61,7 +61,7 @@ def make_plot(tree, variable, selection, binning, xaxis='', title=''):
     tree.Draw(draw_string, selection, "goff")
     output_histo = ROOT.gDirectory.Get("htemp").Clone()
     output_histo.GetXaxis().SetTitle(xaxis)
-    output_histo.SetTitle(title)
+    output_histo.SetTitle("")
     return output_histo
 
 def make_fakerate(denom, num):
@@ -75,7 +75,7 @@ def make_fakerate(denom, num):
 def make_num(ntuple, variable,PtCut,binning):
     num = make_plot(
         ntuple, variable,
-	"fakeEle",
+	"fakeMu",
         binning
     )
     return num
@@ -107,23 +107,24 @@ def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename,
     	frame.UseCurrentStyle()
     	frame.GetXaxis().SetTitle(xaxis)
     	frame.GetYaxis().SetTitle(yaxis)
-    	frame.GetYaxis().SetTitleOffset(1.2)
+    	frame.GetYaxis().SetTitleOffset(1.3)
     	frame.GetYaxis().CenterTitle()
     	frame.GetXaxis().CenterTitle()
     	frame.UseCurrentStyle()
     	frame.Draw()
+	frame.SetTitle("")
 	canvas.SetLogy()
 	for i in range(len(histlist)):
 		if i == 0:
 			histlist[i].Draw('pe')
 		else:
 			histlist[i].Draw('pesame')
-    	legend = ROOT.TLegend(0.65,0.85 ,0.9,1.0, "", "brNDC")
-    	legend.SetFillColor(ROOT.kWhite)
-    	legend.SetBorderSize(1)
-	for i in range(len(legends)):
-		legend.AddEntry(histlist[i],legends[i],'pe')
-    	legend.Draw()
+    	#legend = ROOT.TLegend(0.65,0.85 ,0.9,1.0, "", "brNDC")
+    	#legend.SetFillColor(ROOT.kWhite)
+    	#legend.SetBorderSize(1)
+	#for i in range(len(legends)):
+	#	legend.AddEntry(histlist[i],legends[i],'pe')
+    	#legend.Draw()
     	saveas = saveWhere+filename+'.png'
     	print saveas
     	canvas.SaveAs(saveas)
@@ -132,59 +133,59 @@ def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename,
 # Fake Efficiency for a 20 GeV cut on tau Pt 
 ################################################################################
 ## pT plots
-NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'elePt', 20, [20, 0, 120],#variable, ptcut, binning
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'muPt', 20, [20, 0, 120],#variable, ptcut, binning
                     'tau_iso_fakerate_pT',3e-1,1, #filename, lower bound (y), upper bound (y)
                     "Tau Fake Efficiency (Electrons)",#title
-                    "Tau p_{T} (GeV)",#xaxis
-                    "Fake Efficiency" #yaxis            
+                    "Electron p_{T} (GeV)",#xaxis
+                    "Expected #mu to #tau fake rate" #yaxis            
 )
 
-NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'elePt',20,[20,0,120],
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'muPt',20,[20,0,120],
                     'tau_PtSum_fakerate_pT',1e-1,1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Tau p_{T} (GeV)",
-                    "Fake Efficiency"
+                    "Electron p_{T} (GeV)",
+                    "Expected #mu to #tau fake rate"
 )
 
-NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'elePt',20,[20,0,120],
-                    'tau_Mu_fakerate_pT',6e-1,1,
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'muPt',20,[20,0,120],
+                    'tau_Mu_fakerate_pT',1e-5,1e-1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Tau p_{T} (GeV)",
-                    "Fake Efficiency"
+                    "Muon p_{T} (GeV)",
+                    "Expected #mu to #tau fake rate"
 )
 
-NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'elePt',20,[20,0,120],
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'muPt',20,[20,0,120],
                     'tau_Ele_fakerate_pT',1e-4,1e-1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Tau p_{T} (GeV)",
-                    "Fake Efficiency"
+                    "Electron p_{T} (GeV)",
+                    "Expected #mu to #tau fake rate"
 )
 
 ## eta plots
-NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'eleEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'muEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
                     'tau_iso_fakerate_eta', 3e-1, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Fake Efficiency (Electrons)",#title
-                    "Tau #eta",#xaxis
-                    "Fake Efficiency" #yaxis             
+                    "Muon #Eta",#xaxis
+                    "Expected #mu to #tau fake rate" #yaxis             
 )
-NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'eleEta',20,[20,-2.4,2.4],
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'muEta',20,[20,-2.4,2.4],
                     'tau_PtSum_fakerate_eta',1e-1, 1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Tau #eta",
-                    "Fake Efficiency"
+                    "Muon #Eta",
+                    "Expected #mu to #tau fake rate"
 )
-NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'eleEta',20,[20,-2.4,2.4],
-                    'tau_Mu_fakerate_eta',6e-1, 1,
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'muEta',20,[20,-2.4,2.4],
+                    'tau_Mu_fakerate_eta',1e-5, 1e-1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Tau #eta",
-                    "Fake Efficiency"
+                    "Muon #Eta",
+                    "Expected #mu to #tau fake rate"
 )
 
-NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'eleEta',20,[20,-2.4,2.4],
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'muEta',20,[20,-2.4,2.4],
                     'tau_Ele_fakerate_eta',1e-4, 1e-1,
                     "Tau Fake Efficiency (Electrons)",
-                    "Tau #eta",
-                    "Fake Efficiency"
+                    "Muon #eta",
+                    "Expected #mu to #tau fake rate"
 )
 
 ## nvtx plots
@@ -192,26 +193,26 @@ NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCom
                     'tau_iso_fakerate_nvtx',3e-1, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Fake Efficiency (Electrons)",#title
                     "N_{vtx}",#xaxis
-                    "Fake Efficiency" #yaxis             
+                    "Expected #mu to #tau fake rate" #yaxis             
 )
 
 NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'nvtx',20,[20,0,35],
                     'tau_PtSum_fakerate_nvtx',1e-1, 1,
                     "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
-                    "Fake Efficiency"
+                    "Expected #mu to #tau fake rate"
 )
 
 NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'nvtx',20,[20,0,35],
-                    'tau_Mu_fakerate_nvtx',6e-1, 1,
+                    'tau_Mu_fakerate_nvtx',1e-5, 1e-1,
                     "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
-                    "Fake Efficiency"
+                    "Expected #mu to #tau fake rate"
 )
 
 NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'nvtx',20,[20,0,35],
                     'tau_Ele_fakerate_nvtx',1e-4, 1e-1,
                     "Tau Fake Efficiency (Electrons)",
                     "N_{vtx}",
-                    "Fake Efficiency"
+                    "Expected #mu to #tau fake rate"
 )

--- a/test/plot_Mini_FR_ZToEE.py
+++ b/test/plot_Mini_FR_ZToEE.py
@@ -235,9 +235,14 @@ compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,
                     "Electron Eta",#xaxis
                     "Fake Efficiency" #yaxis             
 )
-
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','eleEta',20,[20,-2.4,2.4],
-                    'tau_Mu_fakeRate_eta_Electrons',1e-1,1,
+                    'tau_PtSum_fakeRate_eta_Electrons',1e-1,1,
+                    "Tau Fake Efficiency (Electrons)",
+                    "Electron Eta",
+                    "Fake Efficiency"
+)
+compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','eleEta',20,[20,-2.4,2.4],
+                    'tau_Mu_fakeRate_eta_Electrons',6e-1,1,
                     "Tau Fake Efficiency (Electrons)",
                     "Electron Eta",
                     "Fake Efficiency"

--- a/test/plot_Mini_effi.py
+++ b/test/plot_Mini_effi.py
@@ -10,14 +10,17 @@ Author: L. Dodd, UW Madison
 
 from subprocess import Popen
 from sys import argv, exit, stdout, stderr
-
+import os
 import ROOT
 
 # So things don't look like crap.
 ROOT.gROOT.SetStyle("Plain")
 ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
-
+ROOT.gStyle.SetPadTopMargin(0.1)
+ROOT.gStyle.SetGridStyle(0)
+ROOT.gStyle.SetTitleX(0.2)
+ROOT.gStyle.SetTitleW(0.6)
 ######## File #########
 if len(argv) < 2:
    print 'Usage:python plot.py RootFile.root label[optional]'
@@ -29,9 +32,9 @@ ntuple_file = ROOT.TFile(infile)
 ######## LABEL & SAVE WHERE #########
 
 if len(argv)>2:
-   saveWhere='~/private/output/tauAnalysis/'+argv[2]+'_'
+   saveWhere='~/private/output/tauAnalysis/7_6_5/'+argv[2]+'_'
 else:
-   saveWhere='~/private/output/tauAnalysis/'
+   saveWhere='~/private/output/tauAnalysis/7_6_5/'
 
 
 
@@ -47,11 +50,12 @@ ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Ntuple")
 puCorrPtSum = ntuple_file.Get("puCorrPtSum/Ntuple")
 MuLoose3 = ntuple_file.Get("againstMuonLoose3/Ntuple")
 MuTight3 = ntuple_file.Get("againstMuonTight3/Ntuple")
-EleVLooseMVA5 = ntuple_file.Get("againstElectronVLooseMVA5/Ntuple")
-EleLooseMVA5 = ntuple_file.Get("againstElectronLooseMVA5/Ntuple")
-EleMediumMVA5 = ntuple_file.Get("againstElectronMediumMVA5/Ntuple")
-
-canvas = ROOT.TCanvas("asdf", "adsf", 800, 800)
+EleVLooseMVA6 = ntuple_file.Get("againstElectronVLooseMVA6/Ntuple")
+EleLooseMVA6 = ntuple_file.Get("againstElectronLooseMVA6/Ntuple")
+EleMediumMVA6 = ntuple_file.Get("againstElectronMediumMVA6/Ntuple")
+EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Ntuple")
+EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Ntuple")
+canvas = ROOT.TCanvas("asdf", "adsf", 1200, 800)
 
 def make_plot(tree, variable, selection, binning, xaxis='', title=''):
     ''' Plot a variable using draw and return the histogram '''
@@ -73,16 +77,15 @@ def make_efficiency(denom, num):
 def make_num(ntuple, variable,PtCut,binning):
     num = make_plot(
         ntuple, variable,
-        "goodReco==1",
+	"goodReco",
         binning
     )
     return num
 
 def make_denom(ntuple, variable,PtCut,binning):
-
     denom = make_plot(
         ntuple, variable,
-        "genMatchedTau==1", #
+        "",
         binning
     )
     return denom
@@ -94,19 +97,25 @@ def produce_efficiency(ntuple, variable, PtCut,binning, filename,color):
     l1.SetMarkerColor(color)
     return l1
 
-def compare_efficiencies(ntuple1,legend1,ntuple2,legend2, variable, PtCut, binning, filename,
+def compare_efficiencies(ntuple1,legend1,ntuple2, legend2, variable, PtCut, binning, filename,framemin,framemax,
                          title='', xaxis='',yaxis=''):
     frame = ROOT.TH1F("frame", "frame", *binning)
     l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
     l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
-    frame.SetMaximum(1.2)
+    frame.SetMaximum(framemax)
+    frame.SetMinimum(framemin)
     frame.SetTitle(title)
+    frame.UseCurrentStyle()
     frame.GetXaxis().SetTitle(xaxis)
     frame.GetYaxis().SetTitle(yaxis)
+    frame.GetYaxis().SetTitleOffset(1.2)
+    frame.GetYaxis().CenterTitle()
+    frame.GetXaxis().CenterTitle()
+    frame.UseCurrentStyle()
     frame.Draw()
     l1.Draw('pe')
     l2.Draw('pesame')
-    legend = ROOT.TLegend(0.5, 0.1, 0.89, 0.4, "", "brNDC")
+    legend = ROOT.TLegend(0.6, 0.75, 0.9, 0.9, "", "brNDC")
     legend.SetFillColor(ROOT.kWhite)
     legend.SetBorderSize(1)
     legend.AddEntry(l1,legend1, "pe")
@@ -116,21 +125,27 @@ def compare_efficiencies(ntuple1,legend1,ntuple2,legend2, variable, PtCut, binni
     print saveas
     canvas.SaveAs(saveas)
 
-def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, variable, PtCut, binning, filename,
+def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, variable, PtCut, binning, filename,framemin,framemax,
                          title='', xaxis='',yaxis=''):
     frame = ROOT.TH1F("frame", "frame", *binning)
     l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
     l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
     l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kRed+3)
-    frame.SetMaximum(1.2)
+    frame.SetMinimum(framemin)
+    frame.SetMaximum(framemax)
     frame.SetTitle(title)
+    frame.UseCurrentStyle()
     frame.GetXaxis().SetTitle(xaxis)
     frame.GetYaxis().SetTitle(yaxis)
+    frame.GetYaxis().SetTitleOffset(1.2)
+    frame.GetYaxis().CenterTitle()
+    frame.GetXaxis().CenterTitle()
     frame.Draw()
     l1.Draw('pe')
     l2.Draw('pesame')
     l3.Draw('pesame')
-    legend = ROOT.TLegend(0.5, 0.7, 0.95, 0.9, "", "brNDC")
+    
+    legend = ROOT.TLegend(0.6, 0.7, 0.9, 0.9, "", "brNDC")
     legend.SetFillColor(ROOT.kWhite)
     legend.SetBorderSize(1)
     legend.AddEntry(l1,legend1, "pe")
@@ -141,92 +156,128 @@ def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, var
     print saveas
     canvas.SaveAs(saveas)
 
+def compare_5efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3,ntuple4,legend4,ntuple5,legend5, variable, PtCut, binning, filename,framemin,framemax,
+                         title='', xaxis='',yaxis=''):
+    frame = ROOT.TH1F("frame", "frame", *binning)
+    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kRed-3)
+    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kRed+3)
+    l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kBlue+3)
+    l4 = produce_efficiency(ntuple4,variable, PtCut,binning, filename,ROOT.kGreen-3)
+    l5 = produce_efficiency(ntuple5,variable, PtCut,binning, filename,ROOT.kGreen+3)
+    frame.SetMinimum(framemin)
+    frame.SetMaximum(framemax)
+    frame.SetTitle(title)
+    frame.UseCurrentStyle()
+    frame.GetXaxis().SetTitle(xaxis)
+    frame.GetYaxis().SetTitle(yaxis)
+    frame.GetYaxis().SetTitleOffset(1.2)
+    frame.GetYaxis().CenterTitle()
+    frame.GetXaxis().CenterTitle()
+    frame.Draw()
+    l1.Draw('pe')
+    l2.Draw('pesame')
+    l3.Draw('pesame')
+    l4.Draw('pesame')
+    l5.Draw('pesame')
+    
+    legend = ROOT.TLegend(0.6, 0.65, 0.9, 0.9, "", "brNDC")
+    legend.SetFillColor(ROOT.kWhite)
+    legend.SetBorderSize(1)
+    legend.AddEntry(l1,legend1, "pe")
+    legend.AddEntry(l2,legend2, "pe")
+    legend.AddEntry(l3,legend3, "pe")
+    legend.AddEntry(l4,legend4, "pe")
+    legend.AddEntry(l5,legend5, "pe")
+    legend.Draw()
+    saveas = saveWhere+filename+'.png'
+    print saveas
+    canvas.SaveAs(saveas)
+
 ################################################################################
 # Efficiency for a 20 GeV cut on tau Pt 
 ################################################################################
-
+## pT plots
 compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','tauPt', 20, [20, 0, 120],#variable, ptcut, binning
-                    'tau_iso_effi_pT',#filename
+                    'tau_iso_effi_pT', 0, 1,#filename
                     "Tau Efficiency",#title
-                    "pf Tau p_{T}",#xaxis
-                    "efficiency" #yaxis             
+                    "Tau p_{T} (GeV)",#xaxis
+                    "Efficiency" #yaxis
+             
 )
 
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','tauPt',20,[20,0,120],
-		    'tau_PtSum_effi_pT',
-		    "Tau Efficiency",
-		    "pf Tau p_{T} (GeV)"
-		    "efficiency"
+                    'tau_PtSum_effi_pT', 0, 1,
+                    "Tau Efficiency",
+                    "Tau p_{T} (GeV)",
+                    "Efficiency"
 )
 
 compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','tauPt',20,[20,0,120],
-                    'tau_Mu_effi_pT',
+                    'tau_Mu_effi_pT', 0, 1,
                     "Tau Efficiency",
-                    "pf Tau p_{T} (GeV)"
-                    "efficiency"
+                    "Tau p_{T} (GeV)",
+                    "Efficiency"
 )
 
-compare_3efficiencies(EleVLooseMVA5,'againstElectronVLooseMVA5',EleLooseMVA5,'againstElectronLooseMVA5',EleMediumMVA5,'againstElectronMediumMVA5','tauPt',20,[20,0,120],
-                    'tau_Ele_effi_pT',
+compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','tauPt',20,[20,0,120],
+                    'tau_Ele_effi_pT', 0, 1,
                     "Tau Efficiency",
-                    "pf Tau p_{T} (GeV)"
-                    "efficiency"
+                    "Tau p_{T} (GeV)",
+                    "Efficiency"
 )
 
 ## eta plots
 compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','tauEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
-                    'tau_iso_effi_eta',#filename
+                    'tau_iso_effi_eta', 0, 1,#filename
                     "Tau Efficiency",#title
-                    "Tau Eta",#xaxis
-                    "efficiency" #yaxis             
+                    "Tau #eta",#xaxis
+                    "Efficiency" #yaxis             
 )
-
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','tauEta',20,[20,-2.4,2.4],
-                    'tau_PtSum_effi_eta',
+                    'tau_PtSum_effi_eta',0, 1,
                     "Tau Efficiency",
-                    "Tau Eta",
-                    "efficiency"
+                    "Tau #eta",
+                    "Efficiency"
 )
-
 compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','tauEta',20,[20,-2.4,2.4],
-                    'tau_Mu_effi_eta',
+                    'tau_Mu_effi_eta',0, 1,
                     "Tau Efficiency",
-                    "Tau Eta",
-                    "efficiency"
+                    "Tau #eta",
+                    "Efficiency"
 )
 
-compare_3efficiencies(EleVLooseMVA5,'againstElectronVLooseMVA5',EleLooseMVA5,'againstElectronLooseMVA5',EleMediumMVA5,'againstElectronMediumMVA5','tauEta',20,[20,-2.4,2.4],
-                    'tau_Ele_effi_eta',
+compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','tauEta',20,[20,-2.4,2.4],
+                    'tau_Ele_effi_eta',0, 1,
                     "Tau Efficiency",
-                    "Tau Eta",
-                    "efficiency"
+                    "Tau #eta",
+                    "Efficiency"
 )
 
 ## nvtx plots
 compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','nvtx', 20, [20,0,35],#variable, ptcut, binning
-                    'tau_iso_effi_nvtx',#filename
+                    'tau_iso_effi_nvtx',0, 1,#filename
                     "Tau Efficiency",#title
                     "N_{vtx}",#xaxis
-                    "efficiency" #yaxis             
+                    "Efficiency" #yaxis             
 )
 
 compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','nvtx',20,[20,0,35],
-                    'tau_PtSum_effi_nvtx',
+                    'tau_PtSum_effi_nvtx',0, 1,
                     "Tau Efficiency",
                     "N_{vtx}",
-                    "efficiency"
+                    "Efficiency"
 )
 
 compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','nvtx',20,[20,0,35],
-                    'tau_Mu_effi_nvtx',
+                    'tau_Mu_effi_nvtx',0, 1,
                     "Tau Efficiency",
                     "N_{vtx}",
-                    "efficiency"
+                    "Efficiency"
 )
 
-compare_3efficiencies(EleVLooseMVA5,'againstElectronVLooseMVA5',EleLooseMVA5,'againstElectronLooseMVA5',EleMediumMVA5,'againstElectronMediumMVA5','nvtx',20,[20,0,35],
-                    'tau_Ele_effi_nvtx',
+compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','nvtx',20,[20,0,35],
+                    'tau_Ele_effi_nvtx',0, 1,
                     "Tau Efficiency",
                     "N_{vtx}",
-                    "efficiency"
+                    "Efficiency"
 )

--- a/test/plot_Mini_effi.py
+++ b/test/plot_Mini_effi.py
@@ -18,9 +18,11 @@ ROOT.gROOT.SetStyle("Plain")
 ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
 ROOT.gStyle.SetPadTopMargin(0.1)
-ROOT.gStyle.SetGridStyle(0)
+ROOT.gStyle.SetPadGridY(1) 
 ROOT.gStyle.SetTitleX(0.2)
 ROOT.gStyle.SetTitleW(0.6)
+colors=[ROOT.kCyan,ROOT.kGreen,ROOT.kOrange,ROOT.kRed,ROOT.kBlue]  #Add more colors for >5 sets of points in a single plot
+
 ######## File #########
 if len(argv) < 2:
    print 'Usage:python plot.py RootFile.root label[optional]'
@@ -30,22 +32,17 @@ infile = argv[1]
 ntuple_file = ROOT.TFile(infile)
 
 ######## LABEL & SAVE WHERE #########
-
 if len(argv)>2:
    saveWhere='~/private/output/tauAnalysis/7_6_5/'+argv[2]+'_'
 else:
    saveWhere='~/private/output/tauAnalysis/7_6_5/'
 
-
-
 #####################################
 #Get Effi NTUPLE                 #
 #####################################
-
 byLooseCmbIso3 = ntuple_file.Get("byLooseCombinedIsolationDeltaBetaCorr3Hits/Ntuple")
 byMedCmbIso3 = ntuple_file.Get("byMediumCombinedIsolationDeltaBetaCorr3Hits/Ntuple")
 byTightCmbIso3 = ntuple_file.Get("byTightCombinedIsolationDeltaBetaCorr3Hits/Ntuple")
-
 ntrlIsoPtSum = ntuple_file.Get("neutralIsoPtSum/Ntuple")
 puCorrPtSum = ntuple_file.Get("puCorrPtSum/Ntuple")
 MuLoose3 = ntuple_file.Get("againstMuonLoose3/Ntuple")
@@ -97,129 +94,64 @@ def produce_efficiency(ntuple, variable, PtCut,binning, filename,color):
     l1.SetMarkerColor(color)
     return l1
 
-def compare_efficiencies(ntuple1,legend1,ntuple2, legend2, variable, PtCut, binning, filename,framemin,framemax,
-                         title='', xaxis='',yaxis=''):
-    frame = ROOT.TH1F("frame", "frame", *binning)
-    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
-    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
-    frame.SetMaximum(framemax)
-    frame.SetMinimum(framemin)
-    frame.SetTitle(title)
-    frame.UseCurrentStyle()
-    frame.GetXaxis().SetTitle(xaxis)
-    frame.GetYaxis().SetTitle(yaxis)
-    frame.GetYaxis().SetTitleOffset(1.2)
-    frame.GetYaxis().CenterTitle()
-    frame.GetXaxis().CenterTitle()
-    frame.UseCurrentStyle()
-    frame.Draw()
-    l1.Draw('pe')
-    l2.Draw('pesame')
-    legend = ROOT.TLegend(0.6, 0.75, 0.9, 0.9, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    legend.SetBorderSize(1)
-    legend.AddEntry(l1,legend1, "pe")
-    legend.AddEntry(l2,legend2, "pe")
-    legend.Draw()
-    saveas = saveWhere+filename+'.png'
-    print saveas
-    canvas.SaveAs(saveas)
-
-def compare_3efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3, variable, PtCut, binning, filename,framemin,framemax,
-                         title='', xaxis='',yaxis=''):
-    frame = ROOT.TH1F("frame", "frame", *binning)
-    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kMagenta-3)
-    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kBlue-9)
-    l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kRed+3)
-    frame.SetMinimum(framemin)
-    frame.SetMaximum(framemax)
-    frame.SetTitle(title)
-    frame.UseCurrentStyle()
-    frame.GetXaxis().SetTitle(xaxis)
-    frame.GetYaxis().SetTitle(yaxis)
-    frame.GetYaxis().SetTitleOffset(1.2)
-    frame.GetYaxis().CenterTitle()
-    frame.GetXaxis().CenterTitle()
-    frame.Draw()
-    l1.Draw('pe')
-    l2.Draw('pesame')
-    l3.Draw('pesame')
-    
-    legend = ROOT.TLegend(0.6, 0.7, 0.9, 0.9, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    legend.SetBorderSize(1)
-    legend.AddEntry(l1,legend1, "pe")
-    legend.AddEntry(l2,legend2, "pe")
-    legend.AddEntry(l3,legend3, "pe")
-    legend.Draw()
-    saveas = saveWhere+filename+'.png'
-    print saveas
-    canvas.SaveAs(saveas)
-
-def compare_5efficiencies(ntuple1,legend1,ntuple2, legend2,ntuple3, legend3,ntuple4,legend4,ntuple5,legend5, variable, PtCut, binning, filename,framemin,framemax,
-                         title='', xaxis='',yaxis=''):
-    frame = ROOT.TH1F("frame", "frame", *binning)
-    l1 = produce_efficiency(ntuple1,variable, PtCut,binning, filename,ROOT.kRed-3)
-    l2 = produce_efficiency(ntuple2,variable, PtCut,binning, filename,ROOT.kRed+3)
-    l3 = produce_efficiency(ntuple3,variable, PtCut,binning, filename,ROOT.kBlue+3)
-    l4 = produce_efficiency(ntuple4,variable, PtCut,binning, filename,ROOT.kGreen-3)
-    l5 = produce_efficiency(ntuple5,variable, PtCut,binning, filename,ROOT.kGreen+3)
-    frame.SetMinimum(framemin)
-    frame.SetMaximum(framemax)
-    frame.SetTitle(title)
-    frame.UseCurrentStyle()
-    frame.GetXaxis().SetTitle(xaxis)
-    frame.GetYaxis().SetTitle(yaxis)
-    frame.GetYaxis().SetTitleOffset(1.2)
-    frame.GetYaxis().CenterTitle()
-    frame.GetXaxis().CenterTitle()
-    frame.Draw()
-    l1.Draw('pe')
-    l2.Draw('pesame')
-    l3.Draw('pesame')
-    l4.Draw('pesame')
-    l5.Draw('pesame')
-    
-    legend = ROOT.TLegend(0.6, 0.65, 0.9, 0.9, "", "brNDC")
-    legend.SetFillColor(ROOT.kWhite)
-    legend.SetBorderSize(1)
-    legend.AddEntry(l1,legend1, "pe")
-    legend.AddEntry(l2,legend2, "pe")
-    legend.AddEntry(l3,legend3, "pe")
-    legend.AddEntry(l4,legend4, "pe")
-    legend.AddEntry(l5,legend5, "pe")
-    legend.Draw()
-    saveas = saveWhere+filename+'.png'
-    print saveas
-    canvas.SaveAs(saveas)
+#Accepts any number of ntuples and plots them for comparison; works well up to at least 5
+def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename, framemin, framemax, title='', xaxis='',yaxis=''):
+	frame = ROOT.TH1F("frame", "frame", *binning)
+	histlist = []
+	for i in range(len(ntuples)):
+		histlist.append(produce_efficiency(ntuples[i],variable, PtCut,binning, filename,colors[i]))
+    	frame.SetMaximum(framemax)
+    	frame.SetMinimum(framemin)
+    	frame.SetTitle(title)
+    	frame.UseCurrentStyle()
+    	frame.GetXaxis().SetTitle(xaxis)
+    	frame.GetYaxis().SetTitle(yaxis)
+    	frame.GetYaxis().SetTitleOffset(1.2)
+    	frame.GetYaxis().CenterTitle()
+    	frame.GetXaxis().CenterTitle()
+    	frame.UseCurrentStyle()
+    	frame.Draw()
+	for i in range(len(histlist)):
+		if i == 0:
+			histlist[i].Draw('pe')
+		else:
+			histlist[i].Draw('pesame')
+    	legend = ROOT.TLegend(0.6,0.8-0.03*len(legends) ,0.9,0.9, "", "brNDC")
+    	legend.SetFillColor(ROOT.kWhite)
+    	legend.SetBorderSize(1)
+	for i in range(len(legends)):
+		legend.AddEntry(histlist[i],legends[i],'pe')
+    	legend.Draw()
+    	saveas = saveWhere+filename+'.png'
+    	print saveas
+    	canvas.SaveAs(saveas)
 
 ################################################################################
 # Efficiency for a 20 GeV cut on tau Pt 
 ################################################################################
 ## pT plots
-compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','tauPt', 20, [20, 0, 120],#variable, ptcut, binning
-                    'tau_iso_effi_pT', 0, 1,#filename
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'tauPt', 20, [20, 0, 120],#variable, ptcut, binning
+                    'tau_iso_effi_pT', 0, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Efficiency",#title
                     "Tau p_{T} (GeV)",#xaxis
-                    "Efficiency" #yaxis
-             
+                    "Efficiency" #yaxis            
 )
 
-compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','tauPt',20,[20,0,120],
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'tauPt',20,[20,0,120],
                     'tau_PtSum_effi_pT', 0, 1,
                     "Tau Efficiency",
                     "Tau p_{T} (GeV)",
                     "Efficiency"
 )
 
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','tauPt',20,[20,0,120],
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'tauPt',20,[20,0,120],
                     'tau_Mu_effi_pT', 0, 1,
                     "Tau Efficiency",
                     "Tau p_{T} (GeV)",
                     "Efficiency"
 )
 
-compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','tauPt',20,[20,0,120],
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'tauPt',20,[20,0,120],
                     'tau_Ele_effi_pT', 0, 1,
                     "Tau Efficiency",
                     "Tau p_{T} (GeV)",
@@ -227,26 +159,26 @@ compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'ag
 )
 
 ## eta plots
-compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','tauEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
-                    'tau_iso_effi_eta', 0, 1,#filename
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'tauEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
+                    'tau_iso_effi_eta', 0, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Efficiency",#title
                     "Tau #eta",#xaxis
                     "Efficiency" #yaxis             
 )
-compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','tauEta',20,[20,-2.4,2.4],
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'tauEta',20,[20,-2.4,2.4],
                     'tau_PtSum_effi_eta',0, 1,
                     "Tau Efficiency",
                     "Tau #eta",
                     "Efficiency"
 )
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','tauEta',20,[20,-2.4,2.4],
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'tauEta',20,[20,-2.4,2.4],
                     'tau_Mu_effi_eta',0, 1,
                     "Tau Efficiency",
                     "Tau #eta",
                     "Efficiency"
 )
 
-compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','tauEta',20,[20,-2.4,2.4],
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'tauEta',20,[20,-2.4,2.4],
                     'tau_Ele_effi_eta',0, 1,
                     "Tau Efficiency",
                     "Tau #eta",
@@ -254,28 +186,28 @@ compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'ag
 )
 
 ## nvtx plots
-compare_3efficiencies(byLooseCmbIso3, 'byLooseCombIsoDBCorr3Hits', byMedCmbIso3,'byMediumCombIsoDBCorr3Hits', byTightCmbIso3,'byTightCombIsoDBCorr3Hits','nvtx', 20, [20,0,35],#variable, ptcut, binning
-                    'tau_iso_effi_nvtx',0, 1,#filename
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'nvtx', 20, [20,0,35],#variable, ptcut, binning
+                    'tau_iso_effi_nvtx',0, 1,#filename, lower bound (y), upper bound (y)
                     "Tau Efficiency",#title
                     "N_{vtx}",#xaxis
                     "Efficiency" #yaxis             
 )
 
-compare_efficiencies(ntrlIsoPtSum,'neutralIsoPtSum',puCorrPtSum,'puCorrPtSum','nvtx',20,[20,0,35],
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'nvtx',20,[20,0,35],
                     'tau_PtSum_effi_nvtx',0, 1,
                     "Tau Efficiency",
                     "N_{vtx}",
                     "Efficiency"
 )
 
-compare_efficiencies(MuLoose3,'againstMuonLoose3',MuTight3,'againstMuonTight3','nvtx',20,[20,0,35],
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'nvtx',20,[20,0,35],
                     'tau_Mu_effi_nvtx',0, 1,
                     "Tau Efficiency",
                     "N_{vtx}",
                     "Efficiency"
 )
 
-compare_5efficiencies(EleVLooseMVA6,'againstElectronVLooseMVA6',EleLooseMVA6,'againstElectronLooseMVA6',EleMediumMVA6,'againstElectronMediumMVA6',EleTightMVA6,'againstElectronTightMVA6',EleVTightMVA6,'againstElectronVTightMVA6','nvtx',20,[20,0,35],
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'nvtx',20,[20,0,35],
                     'tau_Ele_effi_nvtx',0, 1,
                     "Tau Efficiency",
                     "N_{vtx}",

--- a/test/plot_Mini_effi.py
+++ b/test/plot_Mini_effi.py
@@ -12,16 +12,20 @@ from subprocess import Popen
 from sys import argv, exit, stdout, stderr
 import os
 import ROOT
-
+import array
 # So things don't look like crap.
 ROOT.gROOT.SetStyle("Plain")
 ROOT.gROOT.SetBatch(True)
 ROOT.gStyle.SetOptStat(0)
-ROOT.gStyle.SetPadTopMargin(0.1)
-ROOT.gStyle.SetPadGridY(1) 
-ROOT.gStyle.SetTitleX(0.2)
-ROOT.gStyle.SetTitleW(0.6)
+#ROOT.gStyle.SetTitleSize(0.1)
+ROOT.gStyle.SetTitleBorderSize(0)
+#ROOT.gStyle.SetPadTopMargin(0.1)
+ROOT.gStyle.SetPadGridY(1)
+ROOT.gStyle.SetTitleX(0.1)
+ROOT.gStyle.SetTitleY(0.97)
+#ROOT.gStyle.SetTitleW(0.6)
 colors=[ROOT.kCyan,ROOT.kGreen,ROOT.kOrange,ROOT.kRed,ROOT.kBlue]  #Add more colors for >5 sets of points in a single plot
+styles=[20,21,22,23,33]
 
 ######## File #########
 if len(argv) < 2:
@@ -33,9 +37,9 @@ ntuple_file = ROOT.TFile(infile)
 
 ######## LABEL & SAVE WHERE #########
 if len(argv)>2:
-   saveWhere='~/private/output/tauAnalysis/8_0_10/'+argv[2]+'_'
+   saveWhere='~/private/output/tauAnalysis/8_0_10/ZtoTT/'+argv[2]+'_'
 else:
-   saveWhere='~/private/output/tauAnalysis/8_0_10/'
+   saveWhere='~/private/output/tauAnalysis/8_0_10/ZtoTT/'
 
 #####################################
 #Get Effi NTUPLE                 #
@@ -54,20 +58,22 @@ EleTightMVA6 = ntuple_file.Get("againstElectronTightMVA6/Ntuple")
 EleVTightMVA6 = ntuple_file.Get("againstElectronVTightMVA6/Ntuple")
 canvas = ROOT.TCanvas("asdf", "adsf", 1200, 800)
 
-def make_plot(tree, variable, selection, binning, xaxis='', title=''):
+def make_plot(tree, variable, selection, binning, title=''):
     ''' Plot a variable using draw and return the histogram '''
     draw_string = "%s>>htemp(%s)" % (variable, ", ".join(str(x) for x in binning))
     tree.Draw(draw_string, selection, "goff")
     output_histo = ROOT.gDirectory.Get("htemp").Clone()
-    output_histo.GetXaxis().SetTitle(xaxis)
-    output_histo.SetTitle(title)
+    if variable == '':
+	inclusiveBinning = array.array('d', [20,25,30,35,40,45,50,55,60,65,70,80,90,100,120])
+	output_histo = output_histo.Rebin(14,"rebinned",inclusiveBinning)
+    	#l1 = l1.Rebin(2,"hnew",xbins)
     return output_histo
 
 def make_efficiency(denom, num):
     ''' Make an efficiency graph with the style '''
     eff = ROOT.TGraphAsymmErrors(num, denom)
     eff.SetMarkerStyle(20)
-    eff.SetMarkerSize(1.5)
+    eff.SetMarkerSize(2.0)
     eff.SetLineColor(ROOT.kBlack)
     return eff
 
@@ -87,28 +93,32 @@ def make_denom(ntuple, variable,PtCut,binning):
     )
     return denom
 
-def produce_efficiency(ntuple, variable, PtCut,binning, filename,color):
+def produce_efficiency(ntuple, variable, PtCut,binning, filename,color,style):
     denom = make_denom(ntuple, variable,PtCut,binning)
     num = make_num(ntuple,variable,PtCut,binning)
     l1 = make_efficiency(denom,num)
     l1.SetMarkerColor(color)
+    l1.SetMarkerStyle(style)
+    
     return l1
 
 #Accepts any number of ntuples and plots them for comparison; works well up to at least 5
-def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename, framemin, framemax, title='', xaxis='',yaxis=''):
+def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename, framemin, framemax, title, xaxis,yaxis):
 	frame = ROOT.TH1F("frame", "frame", *binning)
 	histlist = []
 	for i in range(len(ntuples)):
-		histlist.append(produce_efficiency(ntuples[i],variable, PtCut,binning, filename,colors[i]))
-    	frame.SetMaximum(framemax)
+		histlist.append(produce_efficiency(ntuples[i],variable, PtCut,binning, filename,colors[i],styles[i]))
+	frame.SetMaximum(framemax)
     	frame.SetMinimum(framemin)
-    	frame.SetTitle(title)
-    	frame.UseCurrentStyle()
-    	frame.GetXaxis().SetTitle(xaxis)
+	#frame.SetTitle('CMS #it{Simulation} Z/#gamma*#rightarrow#tau#tau CMSSW 8_0_10')
+	frame.SetTitle('CMS #it{Simulation} Z*#rightarrow#tau#tau CMSSW 8_0_10')
     	frame.GetYaxis().SetTitle(yaxis)
-    	frame.GetYaxis().SetTitleOffset(1.2)
-    	frame.GetYaxis().CenterTitle()
+    	frame.GetXaxis().SetTitle(xaxis)
+	frame.GetXaxis().SetTitleSize(0.3)
+	frame.GetYaxis().SetTitleSize(0.3)
     	frame.GetXaxis().CenterTitle()
+    	frame.GetYaxis().CenterTitle()
+        #frame.SetNDC(kTRUE)
     	frame.UseCurrentStyle()
     	frame.Draw()
 	for i in range(len(histlist)):
@@ -116,7 +126,7 @@ def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename,
 			histlist[i].Draw('pe')
 		else:
 			histlist[i].Draw('pesame')
-    	legend = ROOT.TLegend(0.6,0.8-0.03*len(legends) ,0.9,0.9, "", "brNDC")
+    	legend = ROOT.TLegend(0.5,0.1 ,0.9,0.1 + 0.07*len(legends), "", "brNDC")
     	legend.SetFillColor(ROOT.kWhite)
     	legend.SetBorderSize(1)
 	for i in range(len(legends)):
@@ -130,86 +140,86 @@ def NewCompareEfficiencies(ntuples, legends, variable, PtCut, binning, filename,
 # Efficiency for a 20 GeV cut on tau Pt 
 ################################################################################
 ## pT plots
-NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'tauPt', 20, [20, 0, 120],#variable, ptcut, binning
-                    'tau_iso_effi_pT', 0, 1,#filename, lower bound (y), upper bound (y)
-                    "Tau Efficiency",#title
-                    "Tau p_{T} (GeV)",#xaxis
-                    "Efficiency" #yaxis            
+NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'tauPt', 20, [24,20,500],#variable, ptcut, binning
+                    'tau_iso_effi_pT_500', 0, 1,#filename, lower bound (y), upper bound (y)
+                    "Expected #tau efficiency",#title
+                    "#tau_{h} p_{T} (GeV)",#xaxis
+                    "Expected #tau efficiency" #yaxis            
 )
 
-NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'tauPt',20,[20,0,120],
-                    'tau_PtSum_effi_pT', 0, 1,
-                    "Tau Efficiency",
-                    "Tau p_{T} (GeV)",
-                    "Efficiency"
+NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'tauPt',20,[24,20,500],
+                    'tau_PtSum_effi_pT_500', 0, 1,
+                    "Expected #tau efficiency",
+                    "#tau_{h} p_{T} (GeV)",
+                    "Expected #tau efficiency"
 )
 
-NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'tauPt',20,[20,0,120],
-                    'tau_Mu_effi_pT', 0, 1,
-                    "Tau Efficiency",
-                    "Tau p_{T} (GeV)",
-                    "Efficiency"
+NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'tauPt',20,[24,20,500],
+                    'tau_Mu_effi_pT_500', 0, 1,
+                    "Expected #tau efficiency",
+                    "#tau_{h} p_{T} (GeV)",
+                    "Expected #tau efficiency"
 )
 
-NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'tauPt',20,[20,0,120],
-                    'tau_Ele_effi_pT', 0, 1,
-                    "Tau Efficiency",
-                    "Tau p_{T} (GeV)",
-                    "Efficiency"
+NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'tauPt',20,[24,20,500],
+                    'tau_Ele_effi_pT_500', 0, 1,
+                    "Expected #tau efficiency",
+                    "#tau_{h} p_{T} (GeV)",
+                    "Expected #tau efficiency"
 )
 
 ## eta plots
 NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'tauEta', 20, [20,-2.4,2.4],#variable, ptcut, binning
                     'tau_iso_effi_eta', 0, 1,#filename, lower bound (y), upper bound (y)
-                    "Tau Efficiency",#title
+                    "Expected #tau efficiency",#title
                     "Tau #eta",#xaxis
-                    "Efficiency" #yaxis             
+                    "Expected #tau efficiency" #yaxis             
 )
 NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'tauEta',20,[20,-2.4,2.4],
                     'tau_PtSum_effi_eta',0, 1,
-                    "Tau Efficiency",
+                    "Expected #tau efficiency",
                     "Tau #eta",
-                    "Efficiency"
+                    "Expected #tau efficiency"
 )
 NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'tauEta',20,[20,-2.4,2.4],
                     'tau_Mu_effi_eta',0, 1,
-                    "Tau Efficiency",
+                    "Expected #tau efficiency",
                     "Tau #eta",
-                    "Efficiency"
+                    "Expected #tau efficiency"
 )
 
 NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'tauEta',20,[20,-2.4,2.4],
                     'tau_Ele_effi_eta',0, 1,
-                    "Tau Efficiency",
+                    "Expected #tau efficiency",
                     "Tau #eta",
-                    "Efficiency"
+                    "Expected #tau efficiency"
 )
 
 ## nvtx plots
 NewCompareEfficiencies([byLooseCmbIso3,byMedCmbIso3,byTightCmbIso3],['byLooseCombIsoDBCorr3Hits','byMediumCombIsoDBCorr3Hits','byTightCombIsoDBCorr3Hits'],'nvtx', 20, [20,0,35],#variable, ptcut, binning
                     'tau_iso_effi_nvtx',0, 1,#filename, lower bound (y), upper bound (y)
-                    "Tau Efficiency",#title
+                    "Expected #tau efficiency",#title
                     "N_{vtx}",#xaxis
-                    "Efficiency" #yaxis             
+                    "Expected #tau efficiency" #yaxis             
 )
 
 NewCompareEfficiencies([ntrlIsoPtSum,puCorrPtSum],['neutralIsoPtSum','puCorrPtSum'],'nvtx',20,[20,0,35],
                     'tau_PtSum_effi_nvtx',0, 1,
-                    "Tau Efficiency",
+                    "Expected #tau efficiency",
                     "N_{vtx}",
-                    "Efficiency"
+                    "Expected #tau efficiency"
 )
 
 NewCompareEfficiencies([MuLoose3,MuTight3],['againstMuonLoose3','againstMuonTight3'],'nvtx',20,[20,0,35],
                     'tau_Mu_effi_nvtx',0, 1,
-                    "Tau Efficiency",
+                    "Expected #tau efficiency",
                     "N_{vtx}",
-                    "Efficiency"
+                    "Expected #tau efficiency"
 )
 
 NewCompareEfficiencies([EleVLooseMVA6,EleLooseMVA6,EleMediumMVA6,EleTightMVA6,EleVTightMVA6],['againstElectronVLooseMVA6','againstElectronLooseMVA6','againstElectronMediumMVA6','againstElectronTightMVA6','againstElectronVTightMVA6'],'nvtx',20,[20,0,35],
                     'tau_Ele_effi_nvtx',0, 1,
-                    "Tau Efficiency",
+                    "Expected #tau efficiency",
                     "N_{vtx}",
-                    "Efficiency"
+                    "Expected #tau efficiency"
 )

--- a/test/plot_Mini_effi.py
+++ b/test/plot_Mini_effi.py
@@ -33,9 +33,9 @@ ntuple_file = ROOT.TFile(infile)
 
 ######## LABEL & SAVE WHERE #########
 if len(argv)>2:
-   saveWhere='~/private/output/tauAnalysis/7_6_5/'+argv[2]+'_'
+   saveWhere='~/private/output/tauAnalysis/8_0_10/'+argv[2]+'_'
 else:
-   saveWhere='~/private/output/tauAnalysis/7_6_5/'
+   saveWhere='~/private/output/tauAnalysis/8_0_10/'
 
 #####################################
 #Get Effi NTUPLE                 #

--- a/test/plot_Mini_effi.py
+++ b/test/plot_Mini_effi.py
@@ -77,7 +77,9 @@ def make_num(ntuple, variable,PtCut,binning):
         binning
     )
     return num
+
 def make_denom(ntuple, variable,PtCut,binning):
+
     denom = make_plot(
         ntuple, variable,
         "genMatchedTau==1", #

--- a/test/runMINIAOD_FR_ZToEE.py
+++ b/test/runMINIAOD_FR_ZToEE.py
@@ -6,10 +6,10 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 #input cmsRun options
 options = VarParsing ('analysis')
-options.inputFiles = "/store/mc/RunIIFall15MiniAODv2/ZToEE_M_120_200_NNPDF30_13TeV_powheg_herwigpp/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/60000/3E9A0052-7A13-E611-B03F-00259055C990.root"
+#options.inputFiles =" /store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
+options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
 options.outputFile = "MiniAOD_FR_ZToEE.root"
 options.parseArguments()
-
 #name the process
 process = cms.Process("TreeProducerFromMiniAOD")
 
@@ -21,7 +21,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 
 #50 ns global tag for MC replace with 'GR_P_V56' for prompt reco. https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Prompt_reconstruction_Global_Tag 
-process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_v6', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_RunIIFall15DR76_v1', '')
 
 #how many events to run over
 process.maxEvents = cms.untracked.PSet(
@@ -37,7 +37,7 @@ process.source = cms.Source("PoolSource",
 process.byLooseCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("byLooseCombinedIsolationDeltaBetaCorr3Hits"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")                                           
@@ -45,7 +45,7 @@ process.byLooseCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODfake
 process.byMediumCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("byMediumCombinedIsolationDeltaBetaCorr3Hits"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
@@ -53,7 +53,7 @@ process.byMediumCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODfak
 process.byTightCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("byTightCombinedIsolationDeltaBetaCorr3Hits"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
@@ -61,7 +61,7 @@ process.byTightCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODfake
 process.neutralIsoPtSum= cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("neutralIsoPtSum"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
@@ -69,7 +69,7 @@ process.neutralIsoPtSum= cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
 process.puCorrPtSum= cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("puCorrPtSum"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
@@ -77,7 +77,7 @@ process.puCorrPtSum= cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
 process.againstMuonLoose3 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("againstMuonLoose3"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
@@ -85,32 +85,48 @@ process.againstMuonLoose3 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
 process.againstMuonTight3 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
     tauID = cms.string("againstMuonTight3"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-process.againstElectronVLooseMVA5 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
+process.againstElectronVLooseMVA6 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
-    tauID = cms.string("againstElectronVLooseMVA5"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
+    tauID = cms.string("againstElectronVLooseMVA6"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-process.againstElectronLooseMVA5 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
+process.againstElectronLooseMVA6 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
-    tauID = cms.string("againstElectronLooseMVA5"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
+    tauID = cms.string("againstElectronLooseMVA6"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-process.againstElectronMediumMVA5 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
+process.againstElectronMediumMVA6 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     taus = cms.InputTag("slimmedTaus"),
-    electrons = cms.InputTag("slimmedElectrons"),
-    tauID = cms.string("againstElectronMediumMVA5"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
+    tauID = cms.string("againstElectronMediumMVA6"),
+    packed = cms.InputTag("packedGenParticles"),
+    pruned = cms.InputTag("prunedGenParticles")
+)
+process.againstElectronTightMVA6 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    taus = cms.InputTag("slimmedTaus"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
+    tauID = cms.string("againstElectronTightMVA6"),
+    packed = cms.InputTag("packedGenParticles"),
+    pruned = cms.InputTag("prunedGenParticles")
+)
+process.againstElectronVTightMVA6 = cms.EDAnalyzer("MiniAODfakeRate_ZToEE",
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    taus = cms.InputTag("slimmedTaus"),
+    electrons = cms.InputTag("slimmedElectrons"), muons = cms.InputTag("slimmedMuons"),
+    tauID = cms.string("againstElectronVTightMVA6"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
@@ -126,9 +142,11 @@ process.p = cms.Path(
 	 	     process.puCorrPtSum*
 		     process.againstMuonLoose3*
 	 	     process.againstMuonTight3*
-		     process.againstElectronVLooseMVA5*
-		     process.againstElectronLooseMVA5*
-		     process.againstElectronMediumMVA5
+		     process.againstElectronVLooseMVA6*
+		     process.againstElectronLooseMVA6*
+		     process.againstElectronMediumMVA6*
+		     process.againstElectronTightMVA6*
+		     process.againstElectronVTightMVA6
                      )
 
 #output file

--- a/test/runMINIAOD_FR_ZToEE.py
+++ b/test/runMINIAOD_FR_ZToEE.py
@@ -6,8 +6,8 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 #input cmsRun options
 options = VarParsing ('analysis')
-#options.inputFiles =" /store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
-options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
+options.inputFiles =" /store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
+#options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
 options.outputFile = "MiniAOD_FR_ZToEE.root"
 options.parseArguments()
 #name the process
@@ -21,7 +21,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 
 #50 ns global tag for MC replace with 'GR_P_V56' for prompt reco. https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Prompt_reconstruction_Global_Tag 
-process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_RunIIFall15DR76_v1', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_RunIIFall15DR76_v1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_v3', '')
 
 #how many events to run over
 process.maxEvents = cms.untracked.PSet(

--- a/test/runMINIAOD_effi.py
+++ b/test/runMINIAOD_effi.py
@@ -3,8 +3,8 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 #input cmsRun options
 options = VarParsing ('analysis')
-#options.inputFiles =" /store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_mini    AODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
-options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
+options.inputFiles ="/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
+#options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
 options.outputFile = "MiniAOD_effi.root"
 options.parseArguments()
 
@@ -18,7 +18,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #50 ns global tag for MC replace with 'GR_P_V56' for prompt reco. https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Prompt_reconstruction_Global_Tag 
 from Configuration.AlCa.GlobalTag import GlobalTag
 #Make sure Global Tag mathes input file type
-process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_RunIIFall15DR76_v1', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_RunIIFall15DR76_v1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_v6', '')
 #how many events to run over
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)

--- a/test/runMINIAOD_effi.py
+++ b/test/runMINIAOD_effi.py
@@ -3,8 +3,8 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 #input cmsRun options
 options = VarParsing ('analysis')
-#options.inputFiles = '/store/mc/RunIISpring15DR74/SUSYGluGluToHToTauTau_M-250_TuneCUETP8M1_13TeV-pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/80000/6EBE4F55-4E03-E511-9FE6-0CC47A13D416.root'
-options.inputFiles = "/store/mc/RunIIFall15DR76/GluGluHToTauTau_M125_13TeV_powheg_pythia8/MINIAODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v12-v1/50000/04CBAD42-759D-E511-943C-0025905A60F8.root"
+#options.inputFiles =" /store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_mini    AODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
+options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
 options.outputFile = "MiniAOD_effi.root"
 options.parseArguments()
 
@@ -17,9 +17,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 #50 ns global tag for MC replace with 'GR_P_V56' for prompt reco. https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Prompt_reconstruction_Global_Tag 
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag.globaltag = 'MCRUN2_74_V9A'
-process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_v6', '')
-
+#Make sure Global Tag mathes input file type
+process.GlobalTag = GlobalTag(process.GlobalTag, '76X_mcRun2_asymptotic_RunIIFall15DR76_v1', '')
 #how many events to run over
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
@@ -34,7 +33,7 @@ process.source = cms.Source("PoolSource",
 # Main
 process.byLooseCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("byLooseCombinedIsolationDeltaBetaCorr3Hits"), 
     packed = cms.InputTag("packedGenParticles"),
@@ -42,7 +41,7 @@ process.byLooseCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeffi
 )
 process.byMediumCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("byMediumCombinedIsolationDeltaBetaCorr3Hits"),
     packed = cms.InputTag("packedGenParticles"),
@@ -50,7 +49,7 @@ process.byMediumCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeff
 )
 process.byTightCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("byTightCombinedIsolationDeltaBetaCorr3Hits"),
     packed = cms.InputTag("packedGenParticles"),
@@ -59,19 +58,19 @@ process.byTightCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeffi
 #It tells me that byCombinedIsolationDeltaBetaCorrRaw3Hits is not in the miniAOD
 #process.byCombinedIsolationDeltaBetaCorr3Hits = cms.EDAnalyzer("MiniAODeffi",
  #   vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-  #  taus = cms.InputTag("slimmedTaus"),
+  #  taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
    # jets = cms.InputTag("slimmedJets"),
     #tauID = cms.string("byCombinedIsolationDeltaBetaCorrRaw3Hits")
 #)
 #process.ChargedIsoPtSum = cms.EDAnalyzer("MiniAODeffi",
  #   vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-  #  taus = cms.InputTag("slimmedTaus"),
+  #  taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
    # jets = cms.InputTag("slimmedJets"),
     #tauID = cms.string("chargedIsoPtSum")
 #)
 process.neutralIsoPtSum= cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("neutralIsoPtSum"),
     packed = cms.InputTag("packedGenParticles"),
@@ -79,7 +78,7 @@ process.neutralIsoPtSum= cms.EDAnalyzer("MiniAODeffi",
 )
 process.puCorrPtSum= cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("puCorrPtSum"),
     packed = cms.InputTag("packedGenParticles"),
@@ -87,7 +86,7 @@ process.puCorrPtSum= cms.EDAnalyzer("MiniAODeffi",
 )
 process.againstMuonLoose3 = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("againstMuonLoose3"),
     packed = cms.InputTag("packedGenParticles"),
@@ -95,37 +94,52 @@ process.againstMuonLoose3 = cms.EDAnalyzer("MiniAODeffi",
 )
 process.againstMuonTight3 = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
     tauID = cms.string("againstMuonTight3"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-process.againstElectronVLooseMVA5 = cms.EDAnalyzer("MiniAODeffi",
+process.againstElectronVLooseMVA6 = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
-    tauID = cms.string("againstElectronVLooseMVA5"),
+    tauID = cms.string("againstElectronVLooseMVA6"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-process.againstElectronLooseMVA5 = cms.EDAnalyzer("MiniAODeffi",
+process.againstElectronLooseMVA6 = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
-    tauID = cms.string("againstElectronLooseMVA5"),
+    tauID = cms.string("againstElectronLooseMVA6"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-process.againstElectronMediumMVA5 = cms.EDAnalyzer("MiniAODeffi",
+process.againstElectronMediumMVA6 = cms.EDAnalyzer("MiniAODeffi",
     vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    taus = cms.InputTag("slimmedTaus"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
     jets = cms.InputTag("slimmedJets"),
-    tauID = cms.string("againstElectronMediumMVA5"),
+    tauID = cms.string("againstElectronMediumMVA6"),
     packed = cms.InputTag("packedGenParticles"),
     pruned = cms.InputTag("prunedGenParticles")
 )
-
+process.againstElectronTightMVA6 = cms.EDAnalyzer("MiniAODeffi",
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
+    jets = cms.InputTag("slimmedJets"),
+    tauID = cms.string("againstElectronTightMVA6"),
+    packed = cms.InputTag("packedGenParticles"),
+    pruned = cms.InputTag("prunedGenParticles")
+)
+process.againstElectronVTightMVA6 = cms.EDAnalyzer("MiniAODeffi",
+    vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
+    taus = cms.InputTag("slimmedTaus"), electrons = cms.InputTag("slimmedElectrons"),
+    jets = cms.InputTag("slimmedJets"),
+    tauID = cms.string("againstElectronVTightMVA6"),
+    packed = cms.InputTag("packedGenParticles"),
+    pruned = cms.InputTag("prunedGenParticles")
+)
 ###################################################
 #Global sequence
 
@@ -139,9 +153,11 @@ process.p = cms.Path(
 	 	     process.puCorrPtSum*
 		     process.againstMuonLoose3*
 	 	     process.againstMuonTight3*
-		     process.againstElectronVLooseMVA5*
-		     process.againstElectronLooseMVA5*
-		     process.againstElectronMediumMVA5
+		     process.againstElectronVLooseMVA6*
+		     process.againstElectronLooseMVA6*
+		     process.againstElectronMediumMVA6*
+		     process.againstElectronTightMVA6*
+		     process.againstElectronVTightMVA6
                      )
 
 process.TFileService = cms.Service("TFileService",

--- a/test/runMINIAOD_effi.py
+++ b/test/runMINIAOD_effi.py
@@ -3,15 +3,19 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 #input cmsRun options
 options = VarParsing ('analysis')
-options.inputFiles ="/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
-#options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root"
-options.outputFile = "MiniAOD_effi.root"
+with open('files2') as f:
+    options.inputFiles = f.readlines()
+
+#options.inputFiles ="/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/50000/127657A5-4E1C-E611-A5B2-001E672486B0.root"
+#options.inputFiles = "/store/mc/RunIISpring16MiniAODv1/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_v3_ext1-v1/20000/0852310B-B6FD-E511-96B1-0002C94CD0B8.root" #smaller set for testing
+#options.inputFiles="/store/mc/RunIIFall15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/70000/068CC5B6-DDB8-E511-82EB-003048FFD756.root" 
+options.outputFile = "MiniAOD_effi_80x_ZtoTT.root"
 options.parseArguments()
 
 #name the process
 process = cms.Process("TreeProducerFromMiniAOD")
 process.load('FWCore/MessageService/MessageLogger_cfi')
-process.MessageLogger.cerr.FwkReport.reportEvery = 100;
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000;
 process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
@@ -22,7 +26,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_v6', '')
 #how many events to run over
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(1000000)
 )
 
 process.source = cms.Source("PoolSource",


### PR DESCRIPTION
I'm thinking the biggest change between old and new efficiency plots comes from the treatment of generated particles.  Before, it looks like all gen. particles were looped through to get the denominator with a "genmatchedTau" discriminator.  Now, it should be looping through generated taus based on the pdgId.
